### PR TITLE
Add support to send frame pickup time via networktables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ set(CUDA_LIB_SOURCES
     src/IntegerValueSender.cpp
     src/BooleanValueSender.cpp
     src/IntegerArraySender.cpp
+    src/NetworkTablesUtil.cpp
     src/video_processor.cu)
 
 # Add a library with the above source files

--- a/src/NetworkTablesUtil.cpp
+++ b/src/NetworkTablesUtil.cpp
@@ -9,5 +9,5 @@ NetworkTablesUtil::NetworkTablesUtil() {
 }
 
 double NetworkTablesUtil::getTime() {
-  return inst_.getFPGATimestamp();
+  return timer_.GetTime();
 }

--- a/src/NetworkTablesUtil.cpp
+++ b/src/NetworkTablesUtil.cpp
@@ -3,9 +3,9 @@
 #include "NetworkTablesConfig.h"
 
 NetworkTablesUtil::NetworkTablesUtil() {
-  inst_ = nt::NetworkTableInstance::GetDefault();
-  inst_.SetServer(TABLE_ADDRESS);
-  inst_.StartClient4(TABLE_ADDRESS);
+//   inst_ = nt::NetworkTableInstance::GetDefault();
+//   inst_.SetServer(TABLE_ADDRESS);
+//   inst_.StartClient4(TABLE_ADDRESS);
 }
 
 double NetworkTablesUtil::getTime() {

--- a/src/NetworkTablesUtil.cpp
+++ b/src/NetworkTablesUtil.cpp
@@ -9,5 +9,5 @@ NetworkTablesUtil::NetworkTablesUtil() {
 }
 
 double NetworkTablesUtil::getTime() {
-  return time_.WPI_GetSystemTime();
+  return wpi::GetSystemTime();
 }

--- a/src/NetworkTablesUtil.cpp
+++ b/src/NetworkTablesUtil.cpp
@@ -9,5 +9,5 @@ NetworkTablesUtil::NetworkTablesUtil() {
 }
 
 double NetworkTablesUtil::getTime() {
-  return timer_.GetTime();
+  return time_.WPI_GetSystemTime();
 }

--- a/src/NetworkTablesUtil.cpp
+++ b/src/NetworkTablesUtil.cpp
@@ -11,14 +11,3 @@ NetworkTablesUtil::NetworkTablesUtil() {
 double NetworkTablesUtil::getTime() {
   return inst_.WPI_GetSystemTime();
 }
-
-// Class use example
-
-// int main(){
-//   DoubleValueSender sender("NVIDIA ORIN TEST");
-//   while(2>1){
-//     sender.sendValue(1.0);
-//     std::cout << "Sent value" << std::endl;
-//   }
-//   return 0;
-// }

--- a/src/NetworkTablesUtil.cpp
+++ b/src/NetworkTablesUtil.cpp
@@ -9,5 +9,5 @@ NetworkTablesUtil::NetworkTablesUtil() {
 }
 
 double NetworkTablesUtil::getTime() {
-  return inst_.WPI_GetSystemTime();
+  return inst_.getFPGATimestamp();
 }

--- a/src/NetworkTablesUtil.cpp
+++ b/src/NetworkTablesUtil.cpp
@@ -1,0 +1,24 @@
+#include "NetworkTablesUtil.h"
+
+#include "NetworkTablesConfig.h"
+
+NetworkTablesUtil::NetworkTablesUtil() {
+  inst_ = nt::NetworkTableInstance::GetDefault();
+  inst_.SetServer(TABLE_ADDRESS);
+  inst_.StartClient4(TABLE_ADDRESS);
+}
+
+double NetworkTablesUtil::getTime() {
+  return inst_.WPI_GetSystemTime();
+}
+
+// Class use example
+
+// int main(){
+//   DoubleValueSender sender("NVIDIA ORIN TEST");
+//   while(2>1){
+//     sender.sendValue(1.0);
+//     std::cout << "Sent value" << std::endl;
+//   }
+//   return 0;
+// }

--- a/src/NetworkTablesUtil.h
+++ b/src/NetworkTablesUtil.h
@@ -2,8 +2,8 @@
 #define NETWORKTABLESUTIL_H
 
 
-#include "networktables/NetworkTable.h"
-#include "networktables/NetworkTableInstance.h"
+//#include "networktables/NetworkTable.h"
+//#include "networktables/NetworkTableInstance.h"
 #include "wpi/timestamp.h"
 
 class NetworkTablesUtil {

--- a/src/NetworkTablesUtil.h
+++ b/src/NetworkTablesUtil.h
@@ -7,8 +7,8 @@
 #include "wpi/timestamp.h"
 
 class NetworkTablesUtil {
- private:
-  nt::NetworkTableInstance inst_;
+ //private:
+  //nt::NetworkTableInstance inst_;
 
  public:
   // Constructor declaration

--- a/src/NetworkTablesUtil.h
+++ b/src/NetworkTablesUtil.h
@@ -4,12 +4,12 @@
 
 #include "networktables/NetworkTable.h"
 #include "networktables/NetworkTableInstance.h"
-#include "networktables/Timer.h"
+#include "wpi/timestamp.h"
 
 class NetworkTablesUtil {
  private:
   nt::NetworkTableInstance inst_;
-  nt::Timer timer_;
+  wpi::timestamp time_;
 
  public:
   // Constructor declaration

--- a/src/NetworkTablesUtil.h
+++ b/src/NetworkTablesUtil.h
@@ -4,10 +4,12 @@
 
 #include "networktables/NetworkTable.h"
 #include "networktables/NetworkTableInstance.h"
+#include "networktables/Timer.h"
 
 class NetworkTablesUtil {
  private:
   nt::NetworkTableInstance inst_;
+  nt::Timer timer_;
 
  public:
   // Constructor declaration

--- a/src/NetworkTablesUtil.h
+++ b/src/NetworkTablesUtil.h
@@ -9,7 +9,6 @@
 class NetworkTablesUtil {
  private:
   nt::NetworkTableInstance inst_;
-  wpi::timestamp time_;
 
  public:
   // Constructor declaration

--- a/src/NetworkTablesUtil.h
+++ b/src/NetworkTablesUtil.h
@@ -1,0 +1,20 @@
+#ifndef NETWORKTABLESUTIL_H
+#define NETWORKTABLESUTIL_H
+
+
+#include "networktables/NetworkTable.h"
+#include "networktables/NetworkTableInstance.h"
+
+class NetworkTablesUtil {
+ private:
+  nt::NetworkTableInstance inst_;
+
+ public:
+  // Constructor declaration
+  NetworkTablesUtil();
+
+  // Method declarations
+  double getTime();
+};
+
+#endif

--- a/src/ws_server.cu
+++ b/src/ws_server.cu
@@ -314,6 +314,7 @@ class AprilTagHandler : public seasocks::WebSocket::Handler {
 
       try {
         cap >> bgr_img;
+        double frameReadTime = ntUtil_.getTime();
         frame_counter++;
 
         auto overallstart = std::chrono::high_resolution_clock::now();
@@ -388,6 +389,7 @@ class AprilTagHandler : public seasocks::WebSocket::Handler {
                                      pose.t->data[2]};
 
             detections_record["detections"].push_back(record);
+            networktables_pose_data.push_back(frameReadTime);
             networktables_pose_data.push_back(det->id * 1.0);
 
             networktables_pose_data.push_back(pose.t->data[0]);
@@ -432,6 +434,7 @@ class AprilTagHandler : public seasocks::WebSocket::Handler {
 
  private:
   DoubleArraySender tagSender_{"raw_pose"};
+  NetworkTablesUtil ntUtil_{};
   std::set<seasocks::WebSocket*> clients_;
   std::mutex mutex_;
   std::shared_ptr<seasocks::Server> server_;

--- a/src/ws_server.cu
+++ b/src/ws_server.cu
@@ -27,6 +27,7 @@
 #include "DoubleValueSender.h"
 #include "IntegerArraySender.h"
 #include "IntegerValueSender.h"
+#include "NetworkTablesUtil.h"
 #include "apriltag_gpu.h"
 #include "apriltag_utils.h"
 #include "cameraexception.h"


### PR DESCRIPTION
Creates a new class NetworkTablesUtil to allow for network tables uses that shouldn't necessarily be found in the sender class. Adds a getTime() method which returns the current time from networktables as a unit_64 double. This is called as soon as the frame is captured, and sent when the frames are sent to the Rio for processing.

<a> https://github.com/wpilibsuite/allwpilib/blob/a41fb460a9f6ba91283bdd9895526cfeba9b8172/wpiutil/src/main/native/cpp/timestamp.cpp#L187 <a> docs