### PR TITLE
Fix typo in install_deps.sh

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -60,7 +60,8 @@ case $arch in
 	    *)
                 echo "Device is not detected to be Jetson Orin Nano; Not installing CUDA."
 	        ;;
-            esac
+        esac
+	;;
     *)
         echo "Unknown architecture: $arch"
         # Handle unknown architecture here


### PR DESCRIPTION
Fixes typo in install_deps.sh script causing installation of CUDA to fail. Typo has escaped into the commit message.