### PR TITLE
fix indexing bug reading translation coeffs from file

### DIFF
--- a/src/ws_server.cu
+++ b/src/ws_server.cu
@@ -198,7 +198,7 @@ class AprilTagHandler : public seasocks::WebSocket::Handler {
       }
     }
     double offsetCoeficients[3] = {0,0,0};
-    for(int i = 0; i < 2; i++){
+    for(int i = 0; i < 3; i++){
       offsetCoeficients[i] = data2["offset"][i];
     }
 


### PR DESCRIPTION
This bug causes our apriltag z position to be off.  The bug is that the last element (z) of the translation vector is not being read from the file and is initialized to zero.  So the code thinks that the camera is located at z=0.